### PR TITLE
make signature creation logic syncronized (mac object isn't thread safe)

### DIFF
--- a/riskified-sdk/src/main/java/com/riskified/RiskifiedClient.java
+++ b/riskified-sdk/src/main/java/com/riskified/RiskifiedClient.java
@@ -1,27 +1,39 @@
 package com.riskified;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.Charset;
-import java.util.Properties;
-
 import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import org.apache.http.*;
-import org.apache.http.auth.*;
-import org.apache.http.client.*;
+import com.riskified.models.*;
+import com.riskified.validations.FieldBadFormatException;
+import com.riskified.validations.IValidated;
+import com.riskified.validations.Validation;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.auth.AUTH;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.MalformedChallengeException;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.entity.StringEntity;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.ContentType;
 import org.apache.http.impl.auth.BasicScheme;
-import org.apache.http.impl.client.*;
+import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.ProxyAuthenticationStrategy;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.util.EntityUtils;
 
-import com.google.gson.Gson;
-import com.riskified.models.*;
-import com.riskified.validations.*;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.Properties;
 
 
 /**
@@ -888,13 +900,12 @@ public class RiskifiedClient {
 
     private void addDataToRequest(Object data, HttpPost postRequest) throws IllegalStateException, UnsupportedEncodingException {
         String jsonData = JSONFormmater.toJson(data);
-
-    	String hmac = sha256Handler.createSHA256(jsonData);
+        byte[] body = jsonData.getBytes("UTF-8");
+    	String hmac = sha256Handler.createSHA256(body);
         postRequest.setHeader("X-RISKIFIED-HMAC-SHA256", hmac);
 
-        StringEntity input;
-        input = new StringEntity(jsonData, Charset.forName("UTF-8"));
-		input.setContentType("application/json");
+        ByteArrayEntity input;
+        input = new ByteArrayEntity(body, ContentType.APPLICATION_JSON);
 		postRequest.setEntity(input);
     }
 

--- a/riskified-sdk/src/main/java/com/riskified/SHA256Handler.java
+++ b/riskified-sdk/src/main/java/com/riskified/SHA256Handler.java
@@ -1,11 +1,11 @@
 package com.riskified;
 
-import java.io.UnsupportedEncodingException;
-import java.security.*;
-import java.util.Formatter;
-
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+import java.util.Formatter;
 
 public class SHA256Handler {
 
@@ -15,19 +15,14 @@ public class SHA256Handler {
         mac = createSHA256Key(authKay);
     }
 
-    public String createSHA256(String data) throws IllegalStateException, UnsupportedEncodingException {
-        final byte[] hmac = mac.doFinal(data.getBytes("UTF-8"));
+    public synchronized String createSHA256(byte[] data) throws IllegalStateException {
+        final byte[] hmac = mac.doFinal(data);
         return toHexString(hmac);
-    }
-
-    public Boolean isHmacCorrect(String data, String hmac) throws IllegalStateException, UnsupportedEncodingException {
-        String calcHash = createSHA256(data);
-        return hmac.equals(calcHash);
     }
 
     private Mac createSHA256Key(String authKey) throws RiskifiedError {
         Key sk = new SecretKeySpec(authKey.getBytes(), "HmacSHA256");
-
+        Mac mac;
         try {
             mac = Mac.getInstance(sk.getAlgorithm());
         } catch (NoSuchAlgorithmException e) {

--- a/riskified-sdk/src/main/java/com/riskified/notifications/NotificationHandler.java
+++ b/riskified-sdk/src/main/java/com/riskified/notifications/NotificationHandler.java
@@ -37,10 +37,11 @@ public class NotificationHandler {
      * @throws JsonSyntaxException json syntax exception
      */
     public Notification toObject(String data, String hash) throws AuthError, JsonSyntaxException, IllegalStateException, UnsupportedEncodingException {
-        if (sha256Handler.isHmacCorrect(data, hash))
+        String calcHash = sha256Handler.createSHA256(data.getBytes("UTF-8"));
+        if (hash.equals(calcHash))
             return gson.fromJson(data, Notification.class);
         else
-            throw new AuthError(hash, sha256Handler.createSHA256(data));
+            throw new AuthError(hash, calcHash);
     }
 
     /**

--- a/riskified-sdk/src/test/java/com/riskified/RiskifiedClientTest.java
+++ b/riskified-sdk/src/test/java/com/riskified/RiskifiedClientTest.java
@@ -1,20 +1,13 @@
 package com.riskified;
 
-import com.riskified.models.ArrayOrders;
-import com.riskified.models.CancelOrder;
-import com.riskified.models.CheckoutOrder;
-import com.riskified.models.DecisionDetails;
-import com.riskified.models.DecisionOrder;
-import com.riskified.models.DecisionType;
-import com.riskified.models.Order;
-import com.riskified.models.ResOrder;
-import com.riskified.models.Response;
+import com.riskified.models.*;
 import com.riskified.validations.FieldBadFormatException;
 import com.riskified.validations.Validation;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.HttpResponseException;
 import org.junit.BeforeClass;
-import org.junit.*;
+import org.junit.Ignore;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -22,9 +15,7 @@ import java.util.Date;
 import java.util.Properties;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 
 public class RiskifiedClientTest {


### PR DESCRIPTION
Sign array of bytes instead of strings to avoid encoding issues