### PR TITLE
Update ResetPasswordStatusType.java - Incorrect Enum value according with documentation: https://apiref.riskified.com/curl/#account-actions-reset-password

### DIFF
--- a/riskified-sdk/src/main/java/com/riskified/models/ResetPasswordStatusType.java
+++ b/riskified-sdk/src/main/java/com/riskified/models/ResetPasswordStatusType.java
@@ -8,7 +8,7 @@ public enum ResetPasswordStatusType {
     pending,
     @SerializedName("success")
     success,
-    @SerializedName("failure")
-    failure
+    @SerializedName("failed")
+    failed
 
 }


### PR DESCRIPTION
Checking you documentation: 
https://apiref.riskified.com/curl/#account-actions-reset-password

status:	
Enum of Strings required
Indicates the status of the request.
Must be one of the following:
pending: Password reset has been requested but new password has not been set.
success: Password has successfully been reset and old password is no longer valid.
failed: Password failed to be reset and old password is still valid.