### PR TITLE
We need to have the Date Formater pattern changed.

### DIFF
--- a/riskified-sdk/src/main/java/com/riskified/JSONFormater.java
+++ b/riskified-sdk/src/main/java/com/riskified/JSONFormater.java
@@ -24,7 +24,7 @@ public class JSONFormater {
 
     public static class DateTimeSerializer implements JsonSerializer<Date> {
         public JsonElement serialize(Date src, Type typeOfSrc, JsonSerializationContext context) {
-            DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mmXXX");
+            DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
             return new JsonPrimitive(df.format(src));
         }
     }


### PR DESCRIPTION
We get the request from our Riskified contact to send the date stamps with seconds, and we detect that this formater is loosing this info.