### PR TITLE
SECURITY-7397 - [ci skip] fix missing codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+/.github/                                                    @Riskified/dev-sre-sg @Riskified/biztech-security-secops-sg
+/.infrastructure/                                            @Riskified/dev-sre-sg @Riskified/biztech-security-secops-sg
+/.infrastructure/terraform/aws/accounts/**/dynamodb.tf       @Riskified/dev-data-data-apps-sg
+/.infrastructure/terraform/aws/accounts/**/elasticache.tf    @Riskified/dev-data-data-apps-sg
+/.metadata/REPOSITORYOWNERS                                  @Riskified/biztech-security-secops-sg


### PR DESCRIPTION

  SUMMARY
  - Fix missing codeowners file in the repository
  - [JIRA](https://riskified.atlassian.net/browse/SECURITY-7397)
