### PR TITLE
DEV-1 Fix: Circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,12 @@ jobs:
 workflows:
   main:
     jobs:
-      - package
+      - package: 
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
       - hold_on_deploy:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,29 +58,31 @@ jobs:
       - run:
           command: mvn -s .circleci/maven-release-settings.xml clean deploy -DdeployAtEnd=true -DperformRelease=true -DskipTests -Dspotbugs.skip=true
 
+all_events: &all_events
+  tags:
+    only: /.*/
+  branches:
+    only: /.*/
+
+tag_only: &tag_only
+  <<: *all_events
+  branches:
+    ignore: /.*/
+
+# Workflow configuration - Runs package on every push; deploys on tag push. 
 workflows:
   main:
     jobs:
-      - package: 
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore: /.*/
+      - package:
+          filters: *all_events
+
       - hold_on_deploy:
           type: approval
           requires:
             - package
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore: /.*/
+          filters: *tag_only
+
       - deploy:
           requires:
             - hold_on_deploy
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore: /.*/
+          filters: *tag_only


### PR DESCRIPTION
Fix for the Circle config. The previous one didn't have filters while other jobs had, which caused a break on the workflow. 

Following [documentation](https://circleci.com/docs/reference/configuration-reference/#filters-1)

**Example of Workflow:**
CI: Every push runs package (build + tests).
Release: Push a tag → package runs → approve hold_on_deploy in CircleCI → deploy publishes to Maven.