### PR TITLE
DEV-129475 | feat: add payment type and sub merchant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Riskified JAVA SDK
 =================
 
-version: 5.0.2
+version: 5.1.0
 ------------------
 
 See http://apiref.riskified.com for full API documentation
@@ -104,7 +104,7 @@ curl -H "Content-Type: application/json" -H  "X-RISKIFIED-HMAC-SHA256: 071ef80d5
 <dependency>
     <groupId>com.riskified</groupId>
     <artifactId>riskified-sdk</artifactId>
-    <version>5.0.2</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 

--- a/riskified-sample/pom.xml
+++ b/riskified-sample/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>com.riskified</groupId>
             <artifactId>riskified-sdk</artifactId>
-            <version>5.0.2</version>
+            <version>5.1.0</version>
         </dependency>
 
         <dependency>

--- a/riskified-sdk/pom.xml
+++ b/riskified-sdk/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.riskified</groupId>
     <artifactId>riskified-sdk</artifactId>
-    <version>5.0.2</version>
+    <version>5.1.0</version>
     <name>Riskified SDK</name>
     <description>Riskified rest api SDK for java</description>
     <url>https://www.riskified.com</url>

--- a/riskified-sdk/src/main/java/com/riskified/RiskifiedClient.java
+++ b/riskified-sdk/src/main/java/com/riskified/RiskifiedClient.java
@@ -1075,7 +1075,7 @@ public class RiskifiedClient {
         postRequest.setHeader(HttpHeaders.ACCEPT, "application/vnd.riskified.com; version=2");
         postRequest.setHeader(HttpHeaders.ACCEPT, "application/json");
         postRequest.setHeader("X-RISKIFIED-SHOP-DOMAIN", shopUrl);
-        postRequest.setHeader("User-Agent","riskified_java_sdk/5.0.2"); // TODO: take the version automatically
+        postRequest.setHeader("User-Agent","riskified_java_sdk/5.1.0"); // TODO: take the version automatically
         postRequest.setHeader("Version",versionHeaderValue);
         return postRequest;
     }

--- a/riskified-sdk/src/main/java/com/riskified/models/BankWirePaymentDetails.java
+++ b/riskified-sdk/src/main/java/com/riskified/models/BankWirePaymentDetails.java
@@ -10,6 +10,7 @@ public class BankWirePaymentDetails implements IPaymentDetails {
     private String token;
     private Date storedPaymentCreatedAt;
     private Date storedPaymentUpdatedAt;
+    private PaymentType paymentType = PaymentType.BANK_TRANSFER;
 
     public BankWirePaymentDetails(String accountNumber, String routingNumber) {
         this.accountNumber = accountNumber;
@@ -55,6 +56,8 @@ public class BankWirePaymentDetails implements IPaymentDetails {
     public void setStoredPaymentUpdatedAt(Date storedPaymentUpdatedAt){
         this.storedPaymentUpdatedAt = storedPaymentUpdatedAt;
     }
+
+    public PaymentType getPaymentType() { return paymentType; }
 
     public void validate(Validation validationType) throws FieldBadFormatException {
         if (validationType == Validation.ALL) {

--- a/riskified-sdk/src/main/java/com/riskified/models/BaseOrder.java
+++ b/riskified-sdk/src/main/java/com/riskified/models/BaseOrder.java
@@ -74,6 +74,7 @@ public abstract class BaseOrder implements IValidated {
     private CommunicationDetails communicationDetails;
     private String submissionReason;
     private Custom custom;
+    private String partnerSubMerchantId;
 
     public BaseOrder() {
     }
@@ -669,6 +670,14 @@ public abstract class BaseOrder implements IValidated {
 
     public void setCustom(Custom custom) {
         this.custom = custom;
+    }
+
+    public String getPartnerSubMerchantId() {
+        return partnerSubMerchantId;
+    }
+
+    public void setPartnerSubMerchantId(String partnerSubMerchantId) {
+        this.partnerSubMerchantId = partnerSubMerchantId;
     }
 
 }

--- a/riskified-sdk/src/main/java/com/riskified/models/CreditCardPaymentDetails.java
+++ b/riskified-sdk/src/main/java/com/riskified/models/CreditCardPaymentDetails.java
@@ -28,7 +28,8 @@ public class CreditCardPaymentDetails implements IPaymentDetails {
     private String acquirerRegion;
     private Integer expiryMonth;
     private Integer expiryYear;
-    
+    private PaymentType paymentType = PaymentType.CARD;
+
 
     public CreditCardPaymentDetails(String creditCardBin, 
     		String avsResultCode, 
@@ -224,5 +225,7 @@ public class CreditCardPaymentDetails implements IPaymentDetails {
     public Integer getExpiryYear() { return expiryYear; }
 
     public void setExpiryYear(Integer expiryYear) { this.expiryYear = expiryYear; }
+
+    public PaymentType getPaymentType() { return paymentType; }
 
 }

--- a/riskified-sdk/src/main/java/com/riskified/models/PaymentType.java
+++ b/riskified-sdk/src/main/java/com/riskified/models/PaymentType.java
@@ -1,0 +1,54 @@
+package com.riskified.models;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum PaymentType {
+
+    @SerializedName("card")
+    CARD,
+    @SerializedName("apple_pay")
+    APPLE_PAY,
+    @SerializedName("google_pay")
+    GOOGLE_PAY,
+    @SerializedName("samsung_pay")
+    SAMSUNG_PAY,
+    @SerializedName("paypal")
+    PAYPAL,
+    @SerializedName("shop_pay")
+    SHOP_PAY,
+    @SerializedName("amazon_pay")
+    AMAZON_PAY,
+    @SerializedName("bnpl")
+    BNPL,
+    @SerializedName("bank_transfer")
+    BANK_TRANSFER,
+    @SerializedName("ach")
+    ACH,
+    @SerializedName("crypto")
+    CRYPTO,
+    @SerializedName("gift_card")
+    GIFT_CARD,
+    @SerializedName("store_credit")
+    STORE_CREDIT,
+    @SerializedName("cash_on_delivery")
+    CASH_ON_DELIVERY,
+    @SerializedName("invoice")
+    INVOICE,
+    @SerializedName("reward_points")
+    REWARD_POINTS,
+    @SerializedName("mobile_carrier")
+    MOBILE_CARRIER,
+    @SerializedName("cashe")
+    CASHE,
+    @SerializedName("check")
+    CHECK,
+    @SerializedName("boleto")
+    BOLETO,
+    @SerializedName("wechat_pay")
+    WECHAT_PAY,
+    @SerializedName("alipay")
+    ALIPAY,
+    @SerializedName("other")
+    OTHER,
+
+}

--- a/riskified-sdk/src/main/java/com/riskified/models/PaypalPaymentDetails.java
+++ b/riskified-sdk/src/main/java/com/riskified/models/PaypalPaymentDetails.java
@@ -18,8 +18,8 @@ public class PaypalPaymentDetails implements IPaymentDetails {
     private String acquirerBin;
     private String mid;
     private AuthorizationType authorizationType;
+    private PaymentType paymentType = PaymentType.PAYPAL;
 
-    
 
     public PaypalPaymentDetails(String payerEmail, String payerStatus, String payerAddressStatus, String protectionEligibility) {
         this.payerEmail = payerEmail;
@@ -146,5 +146,7 @@ public class PaypalPaymentDetails implements IPaymentDetails {
     public AuthorizationType getAuthorizationType() {return authorizationType;}
 
     public void setAuthorizationType(AuthorizationType authorizationType) { this.authorizationType = authorizationType; }
-    
+
+    public PaymentType getPaymentType() { return paymentType; }
+
 }

--- a/riskified-sdk/src/test/java/com/riskified/models/OrderTest.java
+++ b/riskified-sdk/src/test/java/com/riskified/models/OrderTest.java
@@ -1,0 +1,43 @@
+package com.riskified.models;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class OrderTest {
+
+    private Gson gson;
+
+    @Before
+    public void setUp() {
+        gson = new GsonBuilder()
+                .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+                .create();
+    }
+
+    @Test
+    public void testPartnerSubMerchantIdNullByDefault() {
+        Order order = new Order();
+        assertNull(order.getPartnerSubMerchantId());
+    }
+
+    @Test
+    public void testPartnerSubMerchantIdSerializesWithUnderscores() {
+        Order order = new Order();
+        order.setId("order-1");
+        order.setPartnerSubMerchantId("merchant-abc");
+        String json = gson.toJson(order);
+        assertTrue(json.contains("\"partner_sub_merchant_id\":\"merchant-abc\""));
+    }
+
+    @Test
+    public void testPartnerSubMerchantIdDeserializes() {
+        String json = "{\"id\":\"order-1\",\"partner_sub_merchant_id\":\"merchant-xyz\"}";
+        Order order = gson.fromJson(json, Order.class);
+        assertEquals("merchant-xyz", order.getPartnerSubMerchantId());
+    }
+}

--- a/riskified-sdk/src/test/java/com/riskified/models/PaymentDetailsTest.java
+++ b/riskified-sdk/src/test/java/com/riskified/models/PaymentDetailsTest.java
@@ -1,0 +1,60 @@
+package com.riskified.models;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class PaymentDetailsTest {
+
+    private Gson gson;
+
+    @Before
+    public void setUp() {
+        gson = new GsonBuilder()
+                .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+                .create();
+    }
+
+    @Test
+    public void testCreditCardDefaultPaymentType() {
+        CreditCardPaymentDetails cc = new CreditCardPaymentDetails("411111", "Y", "M", "XXXX-1234", "Visa");
+        assertEquals(PaymentType.CARD, cc.getPaymentType());
+    }
+
+    @Test
+    public void testCreditCardPaymentTypeSerializesToCard() {
+        CreditCardPaymentDetails cc = new CreditCardPaymentDetails("411111", "Y", "M", "XXXX-1234", "Visa");
+        String json = gson.toJson(cc);
+        assertTrue(json.contains("\"payment_type\":\"card\""));
+    }
+
+    @Test
+    public void testPaypalDefaultPaymentType() {
+        PaypalPaymentDetails paypal = new PaypalPaymentDetails("buyer@example.com", "verified", "confirmed", "eligible");
+        assertEquals(PaymentType.PAYPAL, paypal.getPaymentType());
+    }
+
+    @Test
+    public void testPaypalPaymentTypeSerializesToPaypal() {
+        PaypalPaymentDetails paypal = new PaypalPaymentDetails("buyer@example.com", "verified", "confirmed", "eligible");
+        String json = gson.toJson(paypal);
+        assertTrue(json.contains("\"payment_type\":\"paypal\""));
+    }
+
+    @Test
+    public void testBankWireDefaultPaymentType() {
+        BankWirePaymentDetails bankWire = new BankWirePaymentDetails("123456789", "021000021");
+        assertEquals(PaymentType.BANK_TRANSFER, bankWire.getPaymentType());
+    }
+
+    @Test
+    public void testBankWirePaymentTypeSerializesToBankTransfer() {
+        BankWirePaymentDetails bankWire = new BankWirePaymentDetails("123456789", "021000021");
+        String json = gson.toJson(bankWire);
+        assertTrue(json.contains("\"payment_type\":\"bank_transfer\""));
+    }
+}


### PR DESCRIPTION
Add payment type for all implementations of `IPaymentDetails`, which are:

- CreditCard
- Paypal
- BankTransfer (BankWire)

Add `partner_sub_merchant_id` optional field to order