### PR TITLE
DEV-131471 SDKs - add plaid data points

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ lib/*
 */target/
 /target/
 /.metadata/
+.metals/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.watcherExclude": {
+        "**/target": true
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.watcherExclude": {
-        "**/target": true
-    }
-}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Riskified JAVA SDK
 =================
 
-version: 6.0.1
+version: 6.0.2
 ------------------
 
 See http://apiref.riskified.com for full API documentation
@@ -104,7 +104,7 @@ curl -H "Content-Type: application/json" -H  "X-RISKIFIED-HMAC-SHA256: 071ef80d5
 <dependency>
     <groupId>com.riskified</groupId>
     <artifactId>riskified-sdk</artifactId>
-    <version>6.0.1</version>
+    <version>6.0.2</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Riskified JAVA SDK
 =================
 
-version: 6.0.2
+version: 6.1.0
 ------------------
 
 See http://apiref.riskified.com for full API documentation
@@ -104,7 +104,7 @@ curl -H "Content-Type: application/json" -H  "X-RISKIFIED-HMAC-SHA256: 071ef80d5
 <dependency>
     <groupId>com.riskified</groupId>
     <artifactId>riskified-sdk</artifactId>
-    <version>6.0.2</version>
+    <version>6.1.0</version>
 </dependency>
 ```
 

--- a/riskified-sample/pom.xml
+++ b/riskified-sample/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>com.riskified</groupId>
             <artifactId>riskified-sdk</artifactId>
-            <version>6.0.2</version>
+            <version>6.1.0</version>
         </dependency>
 
         <dependency>

--- a/riskified-sample/pom.xml
+++ b/riskified-sample/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>com.riskified</groupId>
             <artifactId>riskified-sdk</artifactId>
-            <version>6.0.1</version>
+            <version>6.0.2</version>
         </dependency>
 
         <dependency>

--- a/riskified-sdk/pom.xml
+++ b/riskified-sdk/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.riskified</groupId>
     <artifactId>riskified-sdk</artifactId>
-    <version>6.0.1</version>
+    <version>6.0.2</version>
     <name>Riskified SDK</name>
     <description>Riskified rest api SDK for java</description>
     <url>https://www.riskified.com</url>

--- a/riskified-sdk/pom.xml
+++ b/riskified-sdk/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.riskified</groupId>
     <artifactId>riskified-sdk</artifactId>
-    <version>6.0.2</version>
+    <version>6.1.0</version>
     <name>Riskified SDK</name>
     <description>Riskified rest api SDK for java</description>
     <url>https://www.riskified.com</url>

--- a/riskified-sdk/src/main/java/com/riskified/RiskifiedClient.java
+++ b/riskified-sdk/src/main/java/com/riskified/RiskifiedClient.java
@@ -1075,7 +1075,7 @@ public class RiskifiedClient {
         postRequest.setHeader(HttpHeaders.ACCEPT, "application/vnd.riskified.com; version=2");
         postRequest.setHeader(HttpHeaders.ACCEPT, "application/json");
         postRequest.setHeader("X-RISKIFIED-SHOP-DOMAIN", shopUrl);
-        postRequest.setHeader("User-Agent","riskified_java_sdk/6.0.1"); // TODO: take the version automatically
+        postRequest.setHeader("User-Agent","riskified_java_sdk/6.0.2"); // TODO: take the version automatically
         postRequest.setHeader("Version",versionHeaderValue);
         return postRequest;
     }

--- a/riskified-sdk/src/main/java/com/riskified/RiskifiedClient.java
+++ b/riskified-sdk/src/main/java/com/riskified/RiskifiedClient.java
@@ -1075,7 +1075,7 @@ public class RiskifiedClient {
         postRequest.setHeader(HttpHeaders.ACCEPT, "application/vnd.riskified.com; version=2");
         postRequest.setHeader(HttpHeaders.ACCEPT, "application/json");
         postRequest.setHeader("X-RISKIFIED-SHOP-DOMAIN", shopUrl);
-        postRequest.setHeader("User-Agent","riskified_java_sdk/6.0.2"); // TODO: take the version automatically
+        postRequest.setHeader("User-Agent","riskified_java_sdk/6.1.0"); // TODO: take the version automatically
         postRequest.setHeader("Version",versionHeaderValue);
         return postRequest;
     }

--- a/riskified-sdk/src/main/java/com/riskified/models/BankWirePaymentDetails.java
+++ b/riskified-sdk/src/main/java/com/riskified/models/BankWirePaymentDetails.java
@@ -11,6 +11,12 @@ public class BankWirePaymentDetails implements IPaymentDetails {
     private Date storedPaymentCreatedAt;
     private Date storedPaymentUpdatedAt;
     private PaymentType paymentType = PaymentType.BANK_TRANSFER;
+    private int daysSinceAccountOpening;
+    private int daysWithNegativeBalanceCount;
+    private boolean isSavingsOrMoneyMarketAccount;
+    private int nsfOverdraftTransactionsCount;
+    private int unauthorizedTransactionsCount;
+    private PlaidScores plaidScores;
 
     public BankWirePaymentDetails(String accountNumber, String routingNumber) {
         this.accountNumber = accountNumber;
@@ -56,8 +62,57 @@ public class BankWirePaymentDetails implements IPaymentDetails {
     public void setStoredPaymentUpdatedAt(Date storedPaymentUpdatedAt){
         this.storedPaymentUpdatedAt = storedPaymentUpdatedAt;
     }
+    
 
     public PaymentType getPaymentType() { return paymentType; }
+
+    public int getDaysSinceAccountOpening() {
+        return daysSinceAccountOpening;
+    }
+
+    public void setDaysSinceAccountOpening(int daysSinceAccountOpening) {
+        this.daysSinceAccountOpening = daysSinceAccountOpening;
+    }
+
+    public int getDaysWithNegativeBalanceCount() {
+        return daysWithNegativeBalanceCount;
+    }
+
+    public void setDaysWithNegativeBalanceCount(int daysWithNegativeBalanceCount) {
+        this.daysWithNegativeBalanceCount = daysWithNegativeBalanceCount;
+    }
+
+    public boolean getIsSavingsOrMoneyMarketAccount() {
+        return isSavingsOrMoneyMarketAccount;
+    }
+
+    public void setIsSavingsOrMoneyMarketAccount(boolean isSavingsOrMoneyMarketAccount) {
+        this.isSavingsOrMoneyMarketAccount = isSavingsOrMoneyMarketAccount;
+    }
+
+    public int getNsfOverdraftTransactionsCount() {
+        return nsfOverdraftTransactionsCount;
+    }
+
+    public void setNsfOverdraftTransactionsCount(int nsfOverdraftTransactionsCount) {
+        this.nsfOverdraftTransactionsCount = nsfOverdraftTransactionsCount;
+    }
+
+    public int getUnauthorizedTransactionsCount() {
+        return unauthorizedTransactionsCount;
+    }
+
+    public void setUnauthorizedTransactionsCount(int unauthorizedTransactionsCount) {
+        this.unauthorizedTransactionsCount = unauthorizedTransactionsCount;
+    }
+
+    public PlaidScores getPlaidScores() {
+        return plaidScores;
+    }
+
+    public void setPlaidScores(PlaidScores plaidScores) {
+        this.plaidScores = plaidScores;
+    }
 
     public void validate(Validation validationType) throws FieldBadFormatException {
         if (validationType == Validation.ALL) {
@@ -65,4 +120,5 @@ public class BankWirePaymentDetails implements IPaymentDetails {
             Validate.notNullOrEmpty(this, this.routingNumber, "Bank Routing Number");
         }
     }
+    
 }

--- a/riskified-sdk/src/main/java/com/riskified/models/BankWirePaymentDetails.java
+++ b/riskified-sdk/src/main/java/com/riskified/models/BankWirePaymentDetails.java
@@ -62,7 +62,6 @@ public class BankWirePaymentDetails implements IPaymentDetails {
     public void setStoredPaymentUpdatedAt(Date storedPaymentUpdatedAt){
         this.storedPaymentUpdatedAt = storedPaymentUpdatedAt;
     }
-    
 
     public PaymentType getPaymentType() { return paymentType; }
 

--- a/riskified-sdk/src/main/java/com/riskified/models/InitiatedReturnRisk.java
+++ b/riskified-sdk/src/main/java/com/riskified/models/InitiatedReturnRisk.java
@@ -1,0 +1,20 @@
+package com.riskified.models;
+
+public class InitiatedReturnRisk {
+	private int score; 
+    private int riskTier; 
+
+    public int getScore() {
+        return score;
+    }
+    public void setScore(int score) {
+        this.score = score;
+    }
+    public int getRiskTier() {
+        return riskTier;
+    }
+
+    public void setRiskTier(int riskTier) {
+        this.riskTier = riskTier;
+    }
+}

--- a/riskified-sdk/src/main/java/com/riskified/models/PlaidScores.java
+++ b/riskified-sdk/src/main/java/com/riskified/models/PlaidScores.java
@@ -1,0 +1,22 @@
+package com.riskified.models;
+
+public class PlaidScores {
+	private InitiatedReturnRisk customerInitiatedReturnRisk;
+    private InitiatedReturnRisk bankInitiatedReturnRisk;
+	
+    public InitiatedReturnRisk getCustomerInitiatedReturnRisk() {
+        return customerInitiatedReturnRisk;
+    }
+
+    public void setCustomerInitiatedReturnRisk(InitiatedReturnRisk customerInitiatedReturnRisk) {
+        this.customerInitiatedReturnRisk = customerInitiatedReturnRisk;
+    }
+    
+    public InitiatedReturnRisk getBankInitiatedReturnRisk() {
+        return bankInitiatedReturnRisk;
+    }
+
+    public void setBankInitiatedReturnRisk(InitiatedReturnRisk bankInitiatedReturnRisk) {
+        this.bankInitiatedReturnRisk = bankInitiatedReturnRisk;
+    }
+}

--- a/riskified-sdk/src/test/java/com/riskified/models/PaymentDetailsTest.java
+++ b/riskified-sdk/src/test/java/com/riskified/models/PaymentDetailsTest.java
@@ -57,4 +57,81 @@ public class PaymentDetailsTest {
         String json = gson.toJson(bankWire);
         assertTrue(json.contains("\"payment_type\":\"bank_transfer\""));
     }
+
+    @Test
+    public void testBankWirePlaidScalarFieldsSerializeWithCorrectKeys() {
+        BankWirePaymentDetails bankWire = new BankWirePaymentDetails("123456789", "021000021");
+        bankWire.setDaysSinceAccountOpening(90);
+        bankWire.setDaysWithNegativeBalanceCount(4);
+        bankWire.setIsSavingsOrMoneyMarketAccount(true);
+        bankWire.setNsfOverdraftTransactionsCount(31);
+        bankWire.setUnauthorizedTransactionsCount(2);
+
+        String json = gson.toJson(bankWire);
+
+        assertTrue(json.contains("\"days_since_account_opening\":90"));
+        assertTrue(json.contains("\"days_with_negative_balance_count\":4"));
+        assertTrue(json.contains("\"is_savings_or_money_market_account\":true"));
+        assertTrue(json.contains("\"nsf_overdraft_transactions_count\":31"));
+        assertTrue(json.contains("\"unauthorized_transactions_count\":2"));
+    }
+
+    @Test
+    public void testBankWirePlaidScoresGetterAndSetter() {
+        BankWirePaymentDetails bankWire = new BankWirePaymentDetails("123456789", "021000021");
+
+        InitiatedReturnRisk customerRisk = new InitiatedReturnRisk();
+        customerRisk.setScore(9);
+        customerRisk.setRiskTier(1);
+
+        InitiatedReturnRisk bankRisk = new InitiatedReturnRisk();
+        bankRisk.setScore(82);
+        bankRisk.setRiskTier(7);
+
+        PlaidScores plaidScores = new PlaidScores();
+        plaidScores.setCustomerInitiatedReturnRisk(customerRisk);
+        plaidScores.setBankInitiatedReturnRisk(bankRisk);
+
+        bankWire.setPlaidScores(plaidScores);
+
+        assertEquals(9, bankWire.getPlaidScores().getCustomerInitiatedReturnRisk().getScore());
+        assertEquals(1, bankWire.getPlaidScores().getCustomerInitiatedReturnRisk().getRiskTier());
+        assertEquals(82, bankWire.getPlaidScores().getBankInitiatedReturnRisk().getScore());
+        assertEquals(7, bankWire.getPlaidScores().getBankInitiatedReturnRisk().getRiskTier());
+    }
+
+    @Test
+    public void testBankWirePlaidScoresSerializeWithCorrectStructure() {
+        BankWirePaymentDetails bankWire = new BankWirePaymentDetails("123456789", "021000021");
+
+        InitiatedReturnRisk customerRisk = new InitiatedReturnRisk();
+        customerRisk.setScore(9);
+        customerRisk.setRiskTier(1);
+
+        InitiatedReturnRisk bankRisk = new InitiatedReturnRisk();
+        bankRisk.setScore(82);
+        bankRisk.setRiskTier(7);
+
+        PlaidScores plaidScores = new PlaidScores();
+        plaidScores.setCustomerInitiatedReturnRisk(customerRisk);
+        plaidScores.setBankInitiatedReturnRisk(bankRisk);
+
+        bankWire.setPlaidScores(plaidScores);
+
+        String json = gson.toJson(bankWire);
+
+        assertTrue(json.contains("\"plaid_scores\""));
+        assertTrue(json.contains("\"customer_initiated_return_risk\""));
+        assertTrue(json.contains("\"bank_initiated_return_risk\""));
+        assertTrue(json.contains("\"score\":9"));
+        assertTrue(json.contains("\"risk_tier\":1"));
+        assertTrue(json.contains("\"score\":82"));
+        assertTrue(json.contains("\"risk_tier\":7"));
+    }
+
+    @Test
+    public void testBankWirePlaidScoresNullByDefault() {
+        BankWirePaymentDetails bankWire = new BankWirePaymentDetails("123456789", "021000021");
+        assertNull(bankWire.getPlaidScores());
+    }
 }

--- a/riskified-sdk/src/test/java/com/riskified/models/PaymentDetailsTest.java
+++ b/riskified-sdk/src/test/java/com/riskified/models/PaymentDetailsTest.java
@@ -67,6 +67,20 @@ public class PaymentDetailsTest {
         bankWire.setNsfOverdraftTransactionsCount(31);
         bankWire.setUnauthorizedTransactionsCount(2);
 
+        InitiatedReturnRisk customerRisk = new InitiatedReturnRisk();
+        customerRisk.setScore(9);
+        customerRisk.setRiskTier(1);
+
+        InitiatedReturnRisk bankRisk = new InitiatedReturnRisk();
+        bankRisk.setScore(82);
+        bankRisk.setRiskTier(7);
+
+        PlaidScores plaidScores = new PlaidScores();
+        plaidScores.setCustomerInitiatedReturnRisk(customerRisk);
+        plaidScores.setBankInitiatedReturnRisk(bankRisk);
+
+        bankWire.setPlaidScores(plaidScores);
+
         String json = gson.toJson(bankWire);
 
         assertTrue(json.contains("\"days_since_account_opening\":90"));
@@ -74,52 +88,6 @@ public class PaymentDetailsTest {
         assertTrue(json.contains("\"is_savings_or_money_market_account\":true"));
         assertTrue(json.contains("\"nsf_overdraft_transactions_count\":31"));
         assertTrue(json.contains("\"unauthorized_transactions_count\":2"));
-    }
-
-    @Test
-    public void testBankWirePlaidScoresGetterAndSetter() {
-        BankWirePaymentDetails bankWire = new BankWirePaymentDetails("123456789", "021000021");
-
-        InitiatedReturnRisk customerRisk = new InitiatedReturnRisk();
-        customerRisk.setScore(9);
-        customerRisk.setRiskTier(1);
-
-        InitiatedReturnRisk bankRisk = new InitiatedReturnRisk();
-        bankRisk.setScore(82);
-        bankRisk.setRiskTier(7);
-
-        PlaidScores plaidScores = new PlaidScores();
-        plaidScores.setCustomerInitiatedReturnRisk(customerRisk);
-        plaidScores.setBankInitiatedReturnRisk(bankRisk);
-
-        bankWire.setPlaidScores(plaidScores);
-
-        assertEquals(9, bankWire.getPlaidScores().getCustomerInitiatedReturnRisk().getScore());
-        assertEquals(1, bankWire.getPlaidScores().getCustomerInitiatedReturnRisk().getRiskTier());
-        assertEquals(82, bankWire.getPlaidScores().getBankInitiatedReturnRisk().getScore());
-        assertEquals(7, bankWire.getPlaidScores().getBankInitiatedReturnRisk().getRiskTier());
-    }
-
-    @Test
-    public void testBankWirePlaidScoresSerializeWithCorrectStructure() {
-        BankWirePaymentDetails bankWire = new BankWirePaymentDetails("123456789", "021000021");
-
-        InitiatedReturnRisk customerRisk = new InitiatedReturnRisk();
-        customerRisk.setScore(9);
-        customerRisk.setRiskTier(1);
-
-        InitiatedReturnRisk bankRisk = new InitiatedReturnRisk();
-        bankRisk.setScore(82);
-        bankRisk.setRiskTier(7);
-
-        PlaidScores plaidScores = new PlaidScores();
-        plaidScores.setCustomerInitiatedReturnRisk(customerRisk);
-        plaidScores.setBankInitiatedReturnRisk(bankRisk);
-
-        bankWire.setPlaidScores(plaidScores);
-
-        String json = gson.toJson(bankWire);
-
         assertTrue(json.contains("\"plaid_scores\""));
         assertTrue(json.contains("\"customer_initiated_return_risk\""));
         assertTrue(json.contains("\"bank_initiated_return_risk\""));
@@ -128,7 +96,7 @@ public class PaymentDetailsTest {
         assertTrue(json.contains("\"score\":82"));
         assertTrue(json.contains("\"risk_tier\":7"));
     }
-
+    
     @Test
     public void testBankWirePlaidScoresNullByDefault() {
         BankWirePaymentDetails bankWire = new BankWirePaymentDetails("123456789", "021000021");


### PR DESCRIPTION
## 📌 Related Issues: [DEV-131471](https://riskified.atlassian.net/browse/DEV-131471)

## ✅ Type of Change

- [x] 🚀 Feature

## 📝 Problem Statement

Merchants using the Java SDK have no way to send Plaid bank account data points to Riskified as part of payment details.

## 📝 Solution Overview

Extended `BankWirePaymentDetails` with the following optional fields:

| Field | Type | JSON key |
|---|---|---|
| `daysSinceAccountOpening` | `int` | `days_since_account_opening` |
| `daysWithNegativeBalanceCount` | `int` | `days_with_negative_balance_count` |
| `isSavingsOrMoneyMarketAccount` | `boolean` | `is_savings_or_money_market_account` |
| `nsfOverdraftTransactionsCount` | `int` | `nsf_overdraft_transactions_count` |
| `unauthorizedTransactionsCount` | `int` | `unauthorized_transactions_count` |
| `plaidScores` | `PlaidScores` | `plaid_scores` |

Two new model classes were added to support the nested Plaid scores structure:
- `PlaidScores` — holds `customerInitiatedReturnRisk` and `bankInitiatedReturnRisk`
- `InitiatedReturnRisk` — holds `score` and `riskTier`

Serialization is handled automatically by Gson's `LOWER_CASE_WITH_UNDERSCORES` policy — no annotations required. All new fields are optional and do not affect existing validation logic.

## 🚨 Risks & Considerations

- All new fields are non-mandatory, so existing integrations are fully backwards compatible.
- Primitive fields (`int`, `boolean`) default to `0` / `false` if not set — Gson will serialize them even when unset. Merchants should only populate fields they have data for.

## 🔍 Additional Notes

- `.gitignore` was also cleaned up: reorganised into labelled sections, duplicated patterns removed, and `.metals/` added to prevent Metals LSP artefacts from appearing in PRs.

[DEV-131471]: https://riskified.atlassian.net/browse/DEV-131471