### PR TITLE
DEV-131521: add `account_identity` and `account_balance` support to BankWirePaymentDetails

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Riskified JAVA SDK
 =================
 
-version: 6.1.0
+version: 6.2.0
 ------------------
 
 See http://apiref.riskified.com for full API documentation
@@ -104,7 +104,7 @@ curl -H "Content-Type: application/json" -H  "X-RISKIFIED-HMAC-SHA256: 071ef80d5
 <dependency>
     <groupId>com.riskified</groupId>
     <artifactId>riskified-sdk</artifactId>
-    <version>6.1.0</version>
+    <version>6.2.0</version>
 </dependency>
 ```
 

--- a/riskified-sample/pom.xml
+++ b/riskified-sample/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>com.riskified</groupId>
             <artifactId>riskified-sdk</artifactId>
-            <version>6.1.0</version>
+            <version>6.2.0</version>
         </dependency>
 
         <dependency>

--- a/riskified-sdk/pom.xml
+++ b/riskified-sdk/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.riskified</groupId>
     <artifactId>riskified-sdk</artifactId>
-    <version>6.1.0</version>
+    <version>6.1.1</version>
     <name>Riskified SDK</name>
     <description>Riskified rest api SDK for java</description>
     <url>https://www.riskified.com</url>

--- a/riskified-sdk/pom.xml
+++ b/riskified-sdk/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.riskified</groupId>
     <artifactId>riskified-sdk</artifactId>
-    <version>6.1.1</version>
+    <version>6.2.0</version>
     <name>Riskified SDK</name>
     <description>Riskified rest api SDK for java</description>
     <url>https://www.riskified.com</url>

--- a/riskified-sdk/src/main/java/com/riskified/RiskifiedClient.java
+++ b/riskified-sdk/src/main/java/com/riskified/RiskifiedClient.java
@@ -1075,7 +1075,7 @@ public class RiskifiedClient {
         postRequest.setHeader(HttpHeaders.ACCEPT, "application/vnd.riskified.com; version=2");
         postRequest.setHeader(HttpHeaders.ACCEPT, "application/json");
         postRequest.setHeader("X-RISKIFIED-SHOP-DOMAIN", shopUrl);
-        postRequest.setHeader("User-Agent","riskified_java_sdk/6.1.0"); // TODO: take the version automatically
+        postRequest.setHeader("User-Agent","riskified_java_sdk/6.2.0"); // TODO: take the version automatically
         postRequest.setHeader("Version",versionHeaderValue);
         return postRequest;
     }

--- a/riskified-sdk/src/main/java/com/riskified/models/AccountBalance.java
+++ b/riskified-sdk/src/main/java/com/riskified/models/AccountBalance.java
@@ -1,0 +1,64 @@
+package com.riskified.models;
+
+import com.riskified.validations.*;
+
+import java.util.Date;
+
+/**
+ * Represents account balance information from a financial data provider.
+ * All fields are required.
+ */
+public class AccountBalance implements IValidated {
+
+    private double availableBalance;
+    private AccountBalanceServiceName serviceName;
+    private Date updatedAt;
+    private String currencyCode;
+
+    public AccountBalance(double availableBalance, AccountBalanceServiceName serviceName, Date updatedAt, String currencyCode) {
+        this.availableBalance = availableBalance;
+        this.serviceName = serviceName;
+        this.updatedAt = updatedAt;
+        this.currencyCode = currencyCode;
+    }
+
+    public void validate(Validation validationType) throws FieldBadFormatException {
+        if (validationType == Validation.ALL) {
+            Validate.notNull(this, this.serviceName, "Service Name");
+            Validate.notNull(this, this.updatedAt, "Updated At");
+            Validate.currencyCode(this, this.currencyCode, "Currency Code");
+        }
+    }
+
+    public double getAvailableBalance() {
+        return availableBalance;
+    }
+
+    public void setAvailableBalance(double availableBalance) {
+        this.availableBalance = availableBalance;
+    }
+
+    public AccountBalanceServiceName getServiceName() {
+        return serviceName;
+    }
+
+    public void setServiceName(AccountBalanceServiceName serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    public Date getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Date updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public String getCurrencyCode() {
+        return currencyCode;
+    }
+
+    public void setCurrencyCode(String currencyCode) {
+        this.currencyCode = currencyCode;
+    }
+}

--- a/riskified-sdk/src/main/java/com/riskified/models/AccountBalanceServiceName.java
+++ b/riskified-sdk/src/main/java/com/riskified/models/AccountBalanceServiceName.java
@@ -1,0 +1,24 @@
+package com.riskified.models;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum AccountBalanceServiceName {
+
+    @SerializedName("plaid")
+    PLAID,
+    @SerializedName("mx")
+    MX,
+    @SerializedName("stripe")
+    STRIPE,
+    @SerializedName("truelayer")
+    TRUELAYER,
+    @SerializedName("klarna")
+    KLARNA,
+    @SerializedName("visa")
+    VISA,
+    @SerializedName("mastercard")
+    MASTERCARD,
+    @SerializedName("yodlee")
+    YODLEE,
+
+}

--- a/riskified-sdk/src/main/java/com/riskified/models/AccountIdentity.java
+++ b/riskified-sdk/src/main/java/com/riskified/models/AccountIdentity.java
@@ -1,0 +1,60 @@
+package com.riskified.models;
+
+import com.riskified.validations.*;
+
+import java.util.List;
+
+/**
+ * Represents identity information associated with a payment account.
+ * All fields are optional.
+ */
+public class AccountIdentity implements IValidated {
+
+    private List<String> names;
+    private List<Address> addresses;
+    private List<String> phoneNumbers;
+    private List<String> emails;
+
+    public AccountIdentity() {
+    }
+
+    public void validate(Validation validationType) throws FieldBadFormatException {
+        if (this.addresses != null) {
+            for (Address address : this.addresses) {
+                address.validate(validationType);
+            }
+        }
+    }
+
+    public List<String> getNames() {
+        return names;
+    }
+
+    public void setNames(List<String> names) {
+        this.names = names;
+    }
+
+    public List<Address> getAddresses() {
+        return addresses;
+    }
+
+    public void setAddresses(List<Address> addresses) {
+        this.addresses = addresses;
+    }
+
+    public List<String> getPhoneNumbers() {
+        return phoneNumbers;
+    }
+
+    public void setPhoneNumbers(List<String> phoneNumbers) {
+        this.phoneNumbers = phoneNumbers;
+    }
+
+    public List<String> getEmails() {
+        return emails;
+    }
+
+    public void setEmails(List<String> emails) {
+        this.emails = emails;
+    }
+}

--- a/riskified-sdk/src/main/java/com/riskified/models/BankWirePaymentDetails.java
+++ b/riskified-sdk/src/main/java/com/riskified/models/BankWirePaymentDetails.java
@@ -17,6 +17,8 @@ public class BankWirePaymentDetails implements IPaymentDetails {
     private int nsfOverdraftTransactionsCount;
     private int unauthorizedTransactionsCount;
     private PlaidScores plaidScores;
+    private AccountIdentity accountIdentity;
+    private AccountBalance accountBalance;
 
     public BankWirePaymentDetails(String accountNumber, String routingNumber) {
         this.accountNumber = accountNumber;
@@ -111,6 +113,22 @@ public class BankWirePaymentDetails implements IPaymentDetails {
 
     public void setPlaidScores(PlaidScores plaidScores) {
         this.plaidScores = plaidScores;
+    }
+
+    public AccountIdentity getAccountIdentity() {
+        return accountIdentity;
+    }
+
+    public void setAccountIdentity(AccountIdentity accountIdentity) {
+        this.accountIdentity = accountIdentity;
+    }
+
+    public AccountBalance getAccountBalance() {
+        return accountBalance;
+    }
+
+    public void setAccountBalance(AccountBalance accountBalance) {
+        this.accountBalance = accountBalance;
     }
 
     public void validate(Validation validationType) throws FieldBadFormatException {


### PR DESCRIPTION
## 📌 Related Issues: [DEV-131521](https://riskified.atlassian.net/browse/DEV-131521)

## ✅ Type of Change

- [x] 🚀 Feature
- [ ] 🐛 Bugfix
- [ ] 🔨 Refactor
- [ ] 🧪 Tests
- [ ] 🧹 Chore / Maintenance
- [ ] 📄 Documentation

## 📝 Problem Statement

`BankWirePaymentDetails` lacked support for `account_identity` and `account_balance` objects, needed to pass account holder identity information and real-time balance data (via providers like Plaid, MX, etc.) on bank transfer/ACH orders.

## 📝 Solution Overview

Added two new optional fields to `BankWirePaymentDetails`:

- **`accountIdentity`** — holds names, addresses, phone numbers and emails associated with the payment account
- **`accountBalance`** — holds available balance, service provider, timestamp and currency code

**New files:**
- `AccountIdentity.java` — model with 4 optional fields (`names`, `addresses`, `phoneNumbers`, `emails`)
- `AccountBalance.java` — model with 4 required fields (`availableBalance`, `serviceName`, `updatedAt`, `currencyCode`)
- `AccountBalanceServiceName.java` — enum for the `serviceName` field (`PLAID`, `MX`, `STRIPE`, `TRUELAYER`, `KLARNA`, `VISA`, `MASTERCARD`, `YODLEE`)

**Modified:**
- `BankWirePaymentDetails.java` — added `accountIdentity` and `accountBalance` fields


[DEV-131521]: https://riskified.atlassian.net/browse/DEV-131521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ